### PR TITLE
Fix installation instructions and add start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
  
  cd (repo-name)
 
- npm install -r requirements.txt
+  npm install
 
- node server.js (It will run the server on http://localhost:3000)
+  node server.js (It will run the server on http://localhost:3000)
+  # or use npm start after dependencies are installed
+  npm start

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- correct the install command in the README
- add start instructions using `node server.js` or `npm start`
- provide a start script in `package.json`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688cbc1c21e88329bb4731e4df73e12d