### PR TITLE
Update port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,14 @@
 
  npm install -r requirements.txt
 
- node server.js (It will run the server on http://localhost:3000)
+node server.js (It will run the server on http://localhost:3000)
+
+## Environment Variables
+
+`PORT` - Optional. Specifies the port the server listens on. Defaults to `3000`.
+
+Example:
+
+```
+PORT=4000 node server.js
+```

--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const { PDFDocument } = require("pdf-lib");
 const crypto = require("crypto");
 
 const app = express();
-const PORT = 3000;
+const PORT = process.env.PORT || 3000;
 
 // Paper sizes in points
 const PAPER_SIZES = {


### PR DESCRIPTION
## Summary
- allow port to be configured via `PORT` environment variable
- document `PORT` variable in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688cbc1fa93c832992845fa8aff8b148