### PR TITLE
Use token for unique PDF filenames

### DIFF
--- a/server.js
+++ b/server.js
@@ -71,7 +71,7 @@ app.post("/resize", upload.single("pdf"), async (req, res) => {
       mergedPdf.addPage(copiedPage);
     }
 
-    const mergedFilename = `Order${orderNumber}_File${fileNumber}.pdf`;
+    const mergedFilename = `Order${orderNumber}_File${fileNumber}_${token}.pdf`;
     const mergedPath = path.join(processedDir, mergedFilename);
     const mergedBytes = await mergedPdf.save();
     await fs.promises.writeFile(mergedPath, mergedBytes);


### PR DESCRIPTION
## Summary
- ensure processed PDFs have unique names by appending a token

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688cbc232b948329ad9e33b46e11cc98