### PR TITLE
Validate input for filenames

### DIFF
--- a/server.js
+++ b/server.js
@@ -33,6 +33,17 @@ app.post("/resize", upload.single("pdf"), async (req, res) => {
   const orderNumber = req.body.orderNumber || "0000";
   const fileNumber = req.body.fileNumber || "0";
 
+  const isAlphanumeric = (value) => /^[a-z0-9]+$/i.test(value);
+
+  if (!isAlphanumeric(orderNumber) || !isAlphanumeric(fileNumber)) {
+    return res
+      .status(400)
+      .json({ error: "orderNumber and fileNumber must be alphanumeric." });
+  }
+
+  const safeOrderNumber = path.basename(orderNumber);
+  const safeFileNumber = path.basename(fileNumber);
+
   if (!req.file) {
     return res.status(400).json({ error: "No PDF file uploaded." });
   }
@@ -71,7 +82,7 @@ app.post("/resize", upload.single("pdf"), async (req, res) => {
       mergedPdf.addPage(copiedPage);
     }
 
-    const mergedFilename = `Order${orderNumber}_File${fileNumber}.pdf`;
+    const mergedFilename = `Order${safeOrderNumber}_File${safeFileNumber}.pdf`;
     const mergedPath = path.join(processedDir, mergedFilename);
     const mergedBytes = await mergedPdf.save();
     await fs.promises.writeFile(mergedPath, mergedBytes);


### PR DESCRIPTION
## Summary
- ensure `orderNumber` and `fileNumber` contain only alphanumeric characters
- sanitize inputs before building processed PDF filename

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688cbc2374d88329be27da395acd954a