### PR TITLE
Add Jest tests for resize endpoint

### DIFF
--- a/__tests__/resize.test.js
+++ b/__tests__/resize.test.js
@@ -1,0 +1,39 @@
+const request = require('supertest');
+const { PDFDocument } = require('pdf-lib');
+const fs = require('fs');
+const path = require('path');
+const app = require('../server');
+
+describe('POST /resize', () => {
+  it('resizes an uploaded PDF and returns a PDF', async () => {
+    const pdfDoc = await PDFDocument.create();
+    pdfDoc.addPage([200, 200]);
+    const pdfBytes = await pdfDoc.save();
+
+    const orderNumber = 'test123';
+    const fileNumber = '1';
+
+    const res = await request(app)
+      .post('/resize')
+      .field('size', 'A1')
+      .field('orderNumber', orderNumber)
+      .field('fileNumber', fileNumber)
+      .attach('pdf', Buffer.from(pdfBytes), 'test.pdf');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/pdf/);
+    await PDFDocument.load(res.body);
+
+    const outputPath = path.join('processed', `Order${orderNumber}_File${fileNumber}.pdf`);
+    expect(fs.existsSync(outputPath)).toBe(true);
+    fs.unlinkSync(outputPath);
+  });
+
+  it('returns 400 when no PDF is provided', async () => {
+    const res = await request(app)
+      .post('/resize')
+      .field('size', 'A1');
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -21,5 +21,9 @@
     "express": "^5.1.0",
     "multer": "^2.0.2",
     "pdf-lib": "^1.17.1"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "supertest": "^6.3.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -95,6 +95,10 @@ app.post("/resize", upload.single("pdf"), async (req, res) => {
   }
 });
 
-app.listen(PORT, () => {
-  console.log(`Server running on http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server running on http://localhost:${PORT}`);
+  });
+}
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- export Express app for testing
- add Jest and supertest dev dependencies
- update test script
- create tests for `/resize`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cbc2f1338832989c0a1e23b0d7b26