### PR TITLE
Enhance PDF resizer with login and feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
  
  cd (repo-name)
 
- npm install -r requirements.txt
+ npm install
 
  node server.js (It will run the server on http://localhost:3000)
+
+ Default credentials:
+  - username: admin
+  - password: password

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
+        "express-session": "^1.17.3",
         "multer": "^2.0.2",
         "pdf-lib": "^1.17.1"
       }
@@ -321,6 +322,46 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-SZjssGQC7TzTs9rpPDuUrR23GNZ9+2+IkA/+IJWmvQilTr5OSliEHGF+D9scbIpdC6yGtTI0/VhaHoVes2AN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "2.1.0",
@@ -678,6 +719,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -749,6 +799,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -1006,6 +1065,18 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "express": "^5.1.0",
     "multer": "^2.0.2",
-    "pdf-lib": "^1.17.1"
+    "pdf-lib": "^1.17.1",
+    "express-session": "^1.17.3"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,13 @@
             <option value="A3">A3</option>
           </select>
         </div>
+        <div class="md:col-span-1">
+          <label class="block text-sm font-medium text-gray-700">Processor</label>
+          <select name="processor" class="mt-1 h-11 px-3 rounded-md border border-gray-300 bg-white text-gray-700 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+            <option value="pdf-lib" selected>pdf-lib</option>
+            <option value="mock">mock</option>
+          </select>
+        </div>
       </div>
       <button type="submit" class="w-full bg-blue-600 text-white font-semibold py-2 px-4 rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 transition duration-150">
         Resize PDF
@@ -59,7 +66,8 @@
               <th rowspan="2" class="py-2 px-4 text-left text-sm font-medium text-gray-700">File</th>
               <th colspan="2" class="py-2 px-4 text-center text-sm font-medium text-gray-700">Original</th>
               <th colspan="3" class="py-2 px-4 text-center text-sm font-medium text-gray-700">Processed</th>
-              <th colspan="2" class="py-2 px-4 text-center text-sm font-medium text-gray-700">Action</th>
+              <th rowspan="2" class="py-2 px-4 text-left text-sm font-medium text-gray-700">Processor</th>
+              <th colspan="3" class="py-2 px-4 text-center text-sm font-medium text-gray-700">Action</th>
             </tr>
             <tr class="bg-gray-50">
               <th class="py-2 px-4 text-left text-sm font-medium text-gray-700">Dimensions</th>
@@ -69,6 +77,7 @@
               <th class="py-2 px-4 text-left text-sm font-medium text-gray-700">Time</th>
               <th class="py-2 px-4 text-left text-sm font-medium text-gray-700">Original</th>
               <th class="py-2 px-4 text-left text-sm font-medium text-gray-700">Processed</th>
+              <th class="py-2 px-4 text-left text-sm font-medium text-gray-700">Note</th>
             </tr>
           </thead>
           <tbody id="fileTableBody" class="divide-y divide-gray-200">
@@ -147,8 +156,6 @@
       formData.append('orderNumber', orderNumber);
       formData.append('fileNumber', fileCounter);
 
-      const startTime = performance.now();
-
       try {
         const response = await fetch('/resize', {
           method: 'POST',
@@ -160,16 +167,19 @@
           throw new Error(errorData.error || 'Failed to process PDF');
         }
 
-        const blob = await response.blob();
-        const contentDisposition = response.headers.get('content-disposition');
-        const filenameMatch = contentDisposition && contentDisposition.match(/filename="(.+)"/);
-        const filename = filenameMatch ? filenameMatch[1] : 'processed.pdf';
-        const processingTime = ((performance.now() - startTime) / 1000).toFixed(2);
+        const result = await response.json();
+        const processor = result.record.processor;
+        const processingTime = (result.record.timeMs / 1000).toFixed(2);
+        const blob = new Blob([
+          Uint8Array.from(atob(result.file), c => c.charCodeAt(0))
+        ], { type: 'application/pdf' });
+        const filename = result.record.processedFile;
         const processedFileDimensions = await getPdfDimensions(blob);
         const processedFileSize = blob.size;
 
         const tableBody = document.getElementById('fileTableBody');
         const row = document.createElement('tr');
+        const recordId = result.record.id;
         row.innerHTML = `
           <td class="py-2 px-4 text-sm text-gray-600">${originalFile.name}</td>
           <td class="py-2 px-4 text-sm text-gray-600">${originalFileDimensions.width} x ${originalFileDimensions.height} pt</td>
@@ -177,14 +187,29 @@
           <td class="py-2 px-4 text-sm text-gray-600">${processedFileDimensions.width} x ${processedFileDimensions.height} pt</td>
           <td class="py-2 px-4 text-sm text-gray-600">${formatFileSize(processedFileSize)}</td>
           <td class="py-2 px-4 text-sm text-gray-600">${processingTime} s</td>
+          <td class="py-2 px-4 text-sm text-gray-600">${processor}</td>
           <td class="py-2 px-4 text-sm">
             <a href="${URL.createObjectURL(originalFile)}" download="${originalFile.name}" class="text-blue-600 hover:underline">Download</a>
           </td>
           <td class="py-2 px-4 text-sm">
             <a href="${URL.createObjectURL(blob)}" download="${filename}" class="text-blue-600 hover:underline">Download</a>
           </td>
+          <td class="py-2 px-4 text-sm"><input type="text" class="border rounded-md p-1 text-sm" placeholder="note" /></td>
+          <td class="py-2 px-4 text-sm"><button data-id="${recordId}" data-status="acceptable" class="feedback bg-green-600 text-white px-2 py-1 rounded">Accept</button></td>
+          <td class="py-2 px-4 text-sm"><button data-id="${recordId}" data-status="unacceptable" class="feedback bg-red-600 text-white px-2 py-1 rounded">Reject</button></td>
         `;
         tableBody.appendChild(row);
+        row.querySelectorAll('.feedback').forEach(btn => {
+          btn.addEventListener('click', async () => {
+            const status = btn.dataset.status;
+            const note = row.querySelector('input').value;
+            await fetch('/feedback', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ id: recordId, status, note })
+            });
+          });
+        });
 
         fileCounter++; // Increment file number for next submission
       } catch (error) {

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen flex items-center justify-center py-8">
+  <div class="bg-white p-8 rounded-xl shadow-lg max-w-md w-full">
+    <h1 class="text-2xl font-bold text-gray-800 mb-6 text-center">Login</h1>
+    <form id="loginForm" class="space-y-4">
+      <div>
+        <label class="block text-sm font-medium text-gray-700">Username</label>
+        <input type="text" name="username" required class="mt-1 w-full border border-gray-300 rounded-md p-2" />
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700">Password</label>
+        <input type="password" name="password" required class="mt-1 w-full border border-gray-300 rounded-md p-2" />
+      </div>
+      <button type="submit" class="w-full bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700">Login</button>
+    </form>
+    <p id="error" class="text-red-600 mt-4"></p>
+  </div>
+  <script>
+    document.getElementById('loginForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const formData = new FormData(e.target);
+      const data = Object.fromEntries(formData.entries());
+      const res = await fetch('/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      if (res.ok) {
+        window.location.href = '/';
+      } else {
+        const msg = await res.json();
+        document.getElementById('error').textContent = msg.message || 'Login failed';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add login page and express-session based auth
- store processing and feedback records in memory
- add processor selection and feedback form in UI
- convert `/resize` endpoint to JSON and include chosen processor
- document default credentials in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688cc08cb9388329956b4a33e06cb4a1